### PR TITLE
Fix not depersonifying when clicking the logout button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Not depersonifying when clicking the logout button.
 
 ## [1.4.0] - 2018-10-02
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.4.1] - 2018-10-29
 ### Fixed
 - Not depersonifying when clicking the logout button.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "telemarketing",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "title": "VTEX Telemarketing",
   "defaultLocale": "pt-BR",
   "description": "The VTEX telemarketing app",

--- a/react/index.js
+++ b/react/index.js
@@ -40,7 +40,7 @@ class TelemarketingContainer extends Component {
   }
 
   handleDepersonify = () => {
-    const { depersonify, session } = this.props
+    const { depersonify } = this.props
 
     this.setState({ loadingImpersonate: true })
 
@@ -49,7 +49,7 @@ class TelemarketingContainer extends Component {
         const depersonify = path(['data', 'depersonify'], response)
 
         if (depersonify) {
-          session.refetch()
+          window.location.reload()
         }
 
         this.setState({ loadingImpersonate: false })


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix not depersonifying when clicking the logout button.

#### What problem is this solving?
It was necessary click the logout button twice to logout.

#### How should this be manually tested?
[Click here to access the workspace.](https://waza2--storecomponents.myvtex.com/)

#### Screenshots or example usage
Go to the telemarketing app login with this email `contato@diasbruno.com`, then click in the logout button.

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
