### PR TITLE
Fix bug that misplaced Popover in mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix bug in mobile.
 
 ## [1.4.1] - 2018-10-29
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Fix bug in mobile that misplaced Popover.
+- Fix bug in mobile that misplaced Popover and add top margin to email.
 
 ## [1.4.1] - 2018-10-29
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.4.2] - 2018-11-08
 ### Fixed
 - Fix bug in mobile that misplaced Popover and add top margin to email.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Fix bug in mobile.
+- Fix bug in mobile that misplaced Popover.
 
 ## [1.4.1] - 2018-10-29
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "telemarketing",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "title": "VTEX Telemarketing",
   "defaultLocale": "pt-BR",
   "description": "The VTEX telemarketing app",

--- a/react/components/LoginAsCustomer.js
+++ b/react/components/LoginAsCustomer.js
@@ -48,7 +48,7 @@ export default class LoginAsCustomer extends Component {
             <div className="vtex-telemarketing__popover-header-icon">
               <TelemarketingIcon size={50} />
             </div>
-            <div className="vtex-telemarketing__popover-header-email white-50">
+            <div className="vtex-telemarketing__popover-header-email white-50 mt3">
               {attendantEmail}
             </div>
           </div>

--- a/react/components/Popover.js
+++ b/react/components/Popover.js
@@ -84,4 +84,5 @@ class Popover extends Component {
     )
   }
 }
+
 export default withRuntimeContext(Popover)

--- a/react/components/Popover.js
+++ b/react/components/Popover.js
@@ -1,11 +1,17 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import { path } from 'ramda'
 
 /** Component that shows a content when it´s header is clicked*/
 export default class Popover extends Component {
   static propTypes = {
     /** Function that will display the header */
     renderHeader: PropTypes.func.isRequired,
+    /**  */
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node,
+    ]),
   }
 
   boxRef_ = React.createRef()
@@ -47,6 +53,8 @@ export default class Popover extends Component {
   render() {
     const { renderHeader, children } = this.props
 
+    const isMobile = path(['__RUNTIME__', 'hints', 'mobile'], global)
+
     const boxPositionStyle = {
       right: this.iconRef && this.iconRef.offsetWidth - 43,
     }
@@ -66,7 +74,7 @@ export default class Popover extends Component {
           className={`vtex-popover__box absolute z-max ${
             this.state.isBoxOpen ? 'flex' : 'dn'
           }`}
-          style={boxPositionStyle}
+          style={isMobile ? undefined : boxPositionStyle}
           ref={this.boxRef_}
         >
           <div className="vtex-popover__content-container shadow-3 mt3 bg-white">

--- a/react/components/Popover.js
+++ b/react/components/Popover.js
@@ -71,16 +71,16 @@ export default class Popover extends Component {
           {renderHeader()}
         </div>
         <div
-          className={`vtex-popover__box absolute z-max ${
+          className={`vtex-popover__box absolute top-2 z-max ${
             this.state.isBoxOpen ? 'flex' : 'dn'
           }`}
           style={isMobile ? undefined : boxPositionStyle}
           ref={this.boxRef_}
         >
-          <div className="vtex-popover__content-container shadow-3 mt3 bg-white">
+          <div className="vtex-popover__content-container shadow-3 mt3-ns mt2-s bg-white">
             {children}
           </div>
-          <div className="vtex-popover__arrow-up absolute top-0 right-0-ns bg-white dib-ns dn-s" />
+          <div className="vtex-popover__arrow-up absolute top-0 rotate-135 bg-white dib-ns dn-s" />
         </div>
       </div>
     )

--- a/react/components/Popover.js
+++ b/react/components/Popover.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { path } from 'ramda'
+import { withRuntimeContext } from 'render'
 
 /** Component that shows a content when it´s header is clicked*/
-export default class Popover extends Component {
+class Popover extends Component {
   static propTypes = {
     /** Function that will display the header */
     renderHeader: PropTypes.func.isRequired,
@@ -51,11 +51,9 @@ export default class Popover extends Component {
   }
 
   render() {
-    const { renderHeader, children } = this.props
+    const { renderHeader, children, runtime: { hints: { mobile } } } = this.props
 
-    const isMobile = path(['__RUNTIME__', 'hints', 'mobile'], global)
-
-    const boxPositionStyle = isMobile ? {} : {
+    const boxPositionStyle = mobile ? {} : {
       right: this.iconRef && this.iconRef.offsetWidth - 43,
     }
 
@@ -86,3 +84,4 @@ export default class Popover extends Component {
     )
   }
 }
+export default withRuntimeContext(Popover)

--- a/react/components/Popover.js
+++ b/react/components/Popover.js
@@ -7,7 +7,7 @@ export default class Popover extends Component {
   static propTypes = {
     /** Function that will display the header */
     renderHeader: PropTypes.func.isRequired,
-    /**  */
+    /**  Children that will be rendered inside this Popover*/
     children: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.node),
       PropTypes.node,

--- a/react/components/Popover.js
+++ b/react/components/Popover.js
@@ -55,7 +55,7 @@ export default class Popover extends Component {
 
     const isMobile = path(['__RUNTIME__', 'hints', 'mobile'], global)
 
-    const boxPositionStyle = {
+    const boxPositionStyle = isMobile ? {} : {
       right: this.iconRef && this.iconRef.offsetWidth - 43,
     }
 
@@ -73,8 +73,8 @@ export default class Popover extends Component {
         <div
           className={`vtex-popover__box absolute top-2 z-max ${
             this.state.isBoxOpen ? 'flex' : 'dn'
-          }`}
-          style={isMobile ? undefined : boxPositionStyle}
+            }`}
+          style={boxPositionStyle}
           ref={this.boxRef_}
         >
           <div className="vtex-popover__content-container shadow-3 mt3-ns mt2-s bg-white">

--- a/react/components/Telemarketing.js
+++ b/react/components/Telemarketing.js
@@ -84,4 +84,5 @@ Telemarketing.propTypes = {
   /** Function to depersonify the impersonated customer */
   onDepersonify: PropTypes.func.isRequired,
 }
+
 export default withRuntimeContext(Telemarketing)

--- a/react/components/Telemarketing.js
+++ b/react/components/Telemarketing.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { intlShape } from 'react-intl'
-import { path } from 'ramda'
+import { withRuntimeContext } from 'render'
 
 import LoginAsCustomer from './LoginAsCustomer'
 import LogoutCustomerSession from './LogoutCustomerSession'
@@ -11,7 +11,7 @@ import translate from '../utils/translate'
 import { clientPropTypes } from '../utils/propTypes'
 
 /** Telemarketing render component */
-export default class Telemarketing extends Component {
+class Telemarketing extends Component {
   render() {
     const {
       intl,
@@ -22,9 +22,9 @@ export default class Telemarketing extends Component {
       onSetSession,
       onDepersonify,
       attendantEmail,
+      runtime: { hints: { mobile } }
     } = this.props
 
-    const isMobile = path(['__RUNTIME__', 'hints', 'mobile'], global)
     const isLogged = client
 
     return (
@@ -36,7 +36,7 @@ export default class Telemarketing extends Component {
         <div className="flex items-center">
           <TelemarketingIcon />
 
-          {!isMobile && (
+          {!mobile && (
             <div className="ml2">
               {translate('telemarketing.attendant', intl)}
               <b>{`: ${attendantEmail}`}</b>
@@ -84,3 +84,4 @@ Telemarketing.propTypes = {
   /** Function to depersonify the impersonated customer */
   onDepersonify: PropTypes.func.isRequired,
 }
+export default withRuntimeContext(Telemarketing)

--- a/react/global.css
+++ b/react/global.css
@@ -1,6 +1,5 @@
 .vtex-telemarketing .vtex-popover__arrow-up {
   background-color: rgb(25, 25, 25);
-  right: 20px;
 }
 
 .vtex-telemarketing .vtex-popover__box {
@@ -20,8 +19,7 @@
   transform: rotate(-135deg);
   width: 25px;
   height: 25px;
-  right: 7px;
-  box-shadow: 2px 2px 4px -2px rgba(0, 0, 0, 0.2);
+  left: 86%;
 }
 
 .vtex-popover__box {
@@ -37,11 +35,10 @@
 @media only screen and (max-width: 27em) {
   .vtex-popover__box {
     width: 100vw;
-    top: -3vw;
-    right: -3vw;
+    right: -1vw;
   }
 
   .vtex-telemarketing .vtex-popover__box {
-    top: 2vh;
+    top: 5vw;
   }
 }

--- a/react/global.css
+++ b/react/global.css
@@ -3,7 +3,6 @@
 }
 
 .vtex-telemarketing .vtex-popover__box {
-  top: 2rem;
   min-width: 320px;
 }
 
@@ -16,14 +15,12 @@
 /* Popover css */
 
 .vtex-popover__arrow-up {
-  transform: rotate(-135deg);
   width: 25px;
   height: 25px;
   left: 86%;
 }
 
 .vtex-popover__box {
-  top: 100%;
   visibility: visible;
   min-width: 310px;
 }
@@ -40,5 +37,13 @@
 
   .vtex-telemarketing .vtex-popover__box {
     top: 5vw;
+  }
+}
+
+@media screen and (aspect-ratio: 40/71) {
+  .vtex-popover__box {
+    right: -1.1vw;
+    width: 100vw;
+    top: 3.2vh !important;
   }
 }

--- a/react/index.js
+++ b/react/index.js
@@ -14,7 +14,6 @@ import { Queries } from 'vtex.store'
 
 import Telemarketing from './components/Telemarketing'
 
-
 import './global.css'
 
 /** The Canonical Telemarketing component impersonates an attendant, with the right permissions, as a client. */
@@ -117,7 +116,7 @@ const options = {
   }),
 }
 
-export default withSession({loading: Fragment})(compose(
+export default withSession({ loading: Fragment })(compose(
   injectIntl,
   graphql(Queries.session, options),
   graphql(depersonifyMutation, { name: 'depersonify' }),


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Popover wasn't working as expected in mobile, this PR fix that. 

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Allow mobile users to use telemarketing.

#### How should this be manually tested?
[Access this workspace](https://fixtelemarketing--storecomponents.myvtex.com/samsung-s9-x/p)
Remember to reload the page when you change the view to mobile or tablet.

#### Screenshots or example usage
*Before*
![captura de tela de 2018-11-08 13-40-15](https://user-images.githubusercontent.com/4912690/48213169-f531a280-e35b-11e8-989b-e8c71be26be8.png)

*After*
![captura de tela de 2018-11-08 13-40-40](https://user-images.githubusercontent.com/4912690/48213173-f8c52980-e35b-11e8-95de-c5d16e9167a5.png)

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
