### PR TITLE
Added z-index to be visible on top of header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Z-index to be visible on top of header.
 
 ## [2.1.4] - 2018-12-04
 ### Changed

--- a/react/components/Telemarketing.tsx
+++ b/react/components/Telemarketing.tsx
@@ -46,7 +46,7 @@ export class Telemarketing extends Component<Props> {
     const isLogged = client
 
     return (
-      <div className={`vtex-telemarketing force-full-width ph3 ph5-m ph8-l ph9-xl  tc c-on-emphasis h2 flex justify-between w-100 t-mini ${
+      <div className={`vtex-telemarketing force-full-width ph3 ph5-m ph8-l ph9-xl z-3 tc c-on-emphasis h2 flex justify-between w-100 t-mini ${
         client ? 'bg-emphasis' : 'bg-base--inverted'
         } pa2`}
       >


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

#### What problem is this solving?
It's important to notice that Header and Telemarketing need some padding between them. This will be solved on Header component later on.

#### How should this be manually tested?
[Workspace](https://theheadertales--storecomponents.myvtex.com/)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
