### PR TITLE
only render on myvtex.com

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Only render component under `myvtex.com`.
 
 ## [2.9.6] - 2019-08-30
 ### Changed

--- a/react/utils/processSession.ts
+++ b/react/utils/processSession.ts
@@ -1,4 +1,4 @@
-export default (session: Session): ProcessedSession | null => {
+export default (session?: Session): ProcessedSession | null => {
   try {
     if (session && session.getSession && !session.loading) {
       const {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Only do session query when on domain `myvtex.com`

#### What problem is this solving?
Make less queries on session API

#### How should this be manually tested?
https://fidelis--storecomponents.myvtex.com

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
