### PR TITLE
feature/user-not-found-feedback

### DIFF
--- a/react/components/LoginAsCustomer.tsx
+++ b/react/components/LoginAsCustomer.tsx
@@ -30,6 +30,8 @@ interface Props {
   loading: boolean
   /** If is mobile or not */
   mobile: boolean
+  /** Feedback message */
+  feedback: string
 }
 
 /** Component that shows the email input and calls the impersonate function using the Popover component. */
@@ -40,6 +42,7 @@ const LoginAsCustomer = ({
   loading,
   emailInput,
   mobile,
+  feedback,
 }: Props) => {
   const handles = useCssHandles(CSS_HANDLES)
   const handleHeaderRendering = useCallback(
@@ -96,6 +99,13 @@ const LoginAsCustomer = ({
             >
               <FormattedMessage id="store/telemarketing-login.button" />
             </Button>
+            {
+              feedback && feedback.length ? (
+                <p className="tc bg-danger white pa3 f7 br2">
+                  {feedback}
+                </p>
+              ) : <></>
+            }
           </div>
         </div>
       </Popover>

--- a/react/components/Telemarketing.tsx
+++ b/react/components/Telemarketing.tsx
@@ -25,6 +25,8 @@ interface Props {
   emailInput: string
   /** Loading status */
   loading: boolean
+  /** Feedback message */
+  feedback: string
   /** Function to depersonify the impersonated customer */
   onDepersonify: () => any
   /** Function to set the emailInput value */
@@ -44,6 +46,7 @@ const Telemarketing = ({
   onImpersonate,
   onDepersonify,
   attendantEmail,
+  feedback,
 }: Props) => {
   const { isMobile } = useDevice()
   const handles = useCssHandles(CSS_HANDLES)
@@ -96,6 +99,7 @@ const Telemarketing = ({
               onImpersonate={onImpersonate}
               attendantEmail={attendantEmail}
               mobile={isMobile}
+              feedback={feedback}
             />
           )}
         </div>

--- a/react/components/TelemarketingContainer.tsx
+++ b/react/components/TelemarketingContainer.tsx
@@ -17,11 +17,17 @@ interface Props {
   depersonify: () => Promise<void>
   /** Mutation to impersonate a customer */
   impersonate: (s: {}) => Promise<void>
+  /** Message to display when the email typed has no corresponding user */
+  nonexistentUserMessage: string
+  /* Prevent page to refresh and show feedback message */
+  feedbackForNonexistentUser: boolean 
 }
 
-const TelemarketingContainer: FC<Props> = ({ depersonify, impersonate, session }) => {
+const TelemarketingContainer: FC<Props> = ({ depersonify, impersonate, session, nonexistentUserMessage, feedbackForNonexistentUser }) => {
   const [emailInput, setEmailInput] = useState<string>('')
   const [loadingImpersonate, setloadingImpersonate] = useState<boolean>(false)
+  const [feedback, setFeedback] = useState<string>('')
+  const defaultNonexistentUserMessage = 'There are no users with this email';
 
   const processedSession = processSession(session)
 
@@ -53,8 +59,16 @@ const TelemarketingContainer: FC<Props> = ({ depersonify, impersonate, session }
           ['data', 'impersonate', 'impersonate', 'profile'],
           response
         )
-        !!profile && session.refetch()
-        window.location.reload()
+        if (profile) {
+          session.refetch()
+          window.location.reload()
+        }
+        if (!profile && feedbackForNonexistentUser) {
+          setFeedback(nonexistentUserMessage || defaultNonexistentUserMessage)
+          setloadingImpersonate(false);
+        } else {
+          window.location.reload()
+        }
       })
       .catch(() => setloadingImpersonate(false))
   }
@@ -70,6 +84,7 @@ const TelemarketingContainer: FC<Props> = ({ depersonify, impersonate, session }
       onImpersonate={handleImpersonate}
       onDepersonify={handleDepersonify}
       onInputChange={handleInputChange}
+      feedback={feedback}
     />
   )
 }


### PR DESCRIPTION
#### What problem is this solving?

When a personable user tries to personate someone using an email that has no corresponding user registered on CL, the component does not give a feedback informing that the user no registered, as it used to be on legacy version.


#### How to test it?

Go to a store that uses "vtex.telemarketing", log-in as a personable user and then try to log-in using an email that is not registered. 

The fix can be tested on this workspace:
[https://mensajeteleventas--jumboargentinaqavea.myvtex.com](https://mensajeteleventas--jumboargentinaqavea.myvtex.com)


#### Screenshots or example usage:

Before:
![pSvq9ejhRX](https://user-images.githubusercontent.com/13986492/124652175-2d257680-de72-11eb-8ad2-fcb77f602138.gif)

After:
![1tGrrbza0B](https://user-images.githubusercontent.com/13986492/124651731-abcde400-de71-11eb-89e2-76058bcfef95.gif)


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/12xFifV6ykKxc4/giphy.gif)
